### PR TITLE
IKeyResolver implementation for MongoDb pacakge

### DIFF
--- a/ChustaSoft.DBAccess.sln
+++ b/ChustaSoft.DBAccess.sln
@@ -17,7 +17,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ChustaSoft.Tools.DBAccess.E
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ChustaSoft.Tools.DBAccess.EntityFramework.IntegrationTests", "ChustaSoft.Tools.DBAccess.EntityFramework.IntegrationTests\ChustaSoft.Tools.DBAccess.EntityFramework.IntegrationTests.csproj", "{1041C4A0-77EC-4B2F-AA25-A253A86831D6}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests", "ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests\ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests.csproj", "{EB96CB72-C942-49E9-A8EA-9E04CDB420A3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests", "ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests\ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests.csproj", "{EB96CB72-C942-49E9-A8EA-9E04CDB420A3}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -48,7 +48,6 @@ Global
 		{EB96CB72-C942-49E9-A8EA-9E04CDB420A3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{EB96CB72-C942-49E9-A8EA-9E04CDB420A3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EB96CB72-C942-49E9-A8EA-9E04CDB420A3}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{EB96CB72-C942-49E9-A8EA-9E04CDB420A3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ChustaSoft.DBAccess.sln
+++ b/ChustaSoft.DBAccess.sln
@@ -19,6 +19,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ChustaSoft.Tools.DBAccess.E
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests", "ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests\ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests.csproj", "{EB96CB72-C942-49E9-A8EA-9E04CDB420A3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChustaSoft.Tools.DBAccess.MongoDb.UnitTests", "ChustaSoft.Tools.DBAccess.MongoDb.UnitTests\ChustaSoft.Tools.DBAccess.MongoDb.UnitTests.csproj", "{97704D2D-8C48-464E-A260-FB2AF70D47BD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -48,6 +50,10 @@ Global
 		{EB96CB72-C942-49E9-A8EA-9E04CDB420A3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{EB96CB72-C942-49E9-A8EA-9E04CDB420A3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EB96CB72-C942-49E9-A8EA-9E04CDB420A3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{97704D2D-8C48-464E-A260-FB2AF70D47BD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{97704D2D-8C48-464E-A260-FB2AF70D47BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{97704D2D-8C48-464E-A260-FB2AF70D47BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{97704D2D-8C48-464E-A260-FB2AF70D47BD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ChustaSoft.Tools.DBAccess.Abstractions/UnitOfWorkBase.cs
+++ b/ChustaSoft.Tools.DBAccess.Abstractions/UnitOfWorkBase.cs
@@ -11,7 +11,6 @@ namespace ChustaSoft.Tools.DBAccess
 
         protected readonly TContext _context;
 
-
         public UnitOfWorkBase(TContext context)
         {
             _context = context;

--- a/ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests/Base/IntegrationTestBase.cs
+++ b/ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests/Base/IntegrationTestBase.cs
@@ -1,5 +1,4 @@
-﻿using MongoDB.Bson;
-using MongoDB.Driver;
+﻿using MongoDB.Driver;
 using Xunit;
 
 namespace ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests.Base

--- a/ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests/Base/MongoDbIntegrationTestBase.cs
+++ b/ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests/Base/MongoDbIntegrationTestBase.cs
@@ -7,13 +7,13 @@ using Xunit;
 namespace ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests.Base
 {
     [Collection("non-parallel test collection")]
-    public class IntegrationTestBase
+    public class MongoDbIntegrationTestBase
     {
         private MongoClient client;
         protected readonly IUnitOfWork unitOfWork;
         private readonly MongoDatabaseConfiguration configuration;
 
-        public IntegrationTestBase()
+        public MongoDbIntegrationTestBase()
         {
             configuration = GetConfiguration();
             InitializeEmptyDatabase();

--- a/ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests/Base/MongoDbIntegrationTestBase.cs
+++ b/ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests/Base/MongoDbIntegrationTestBase.cs
@@ -1,7 +1,5 @@
 ﻿using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Configuration.Json;
 using MongoDB.Driver;
-using System;
 using Xunit;
 
 namespace ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests.Base

--- a/ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests/Base/MongoDbIntegrationTestBase.cs
+++ b/ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests/Base/MongoDbIntegrationTestBase.cs
@@ -8,15 +8,12 @@ namespace ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests.Base
     public class MongoDbIntegrationTestBase
     {
         private MongoClient client;
-        protected readonly IUnitOfWork unitOfWork;
-        private readonly MongoDatabaseConfiguration configuration;
+        protected readonly MongoDatabaseConfiguration configuration;
 
         public MongoDbIntegrationTestBase()
         {
             configuration = GetConfiguration();
             InitializeEmptyDatabase();
-
-            unitOfWork = CreateUnitOfWork();
         }
 
         private MongoDatabaseConfiguration GetConfiguration()
@@ -39,10 +36,5 @@ namespace ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests.Base
             client.DropDatabase(configuration.DatabaseName);
         }
 
-        private IUnitOfWork CreateUnitOfWork()
-        {
-            var testContext = new MongoContext(configuration);
-            return new UnitOfWork<MongoContext>(testContext);
-        }
     }
 }

--- a/ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests/ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests.csproj
+++ b/ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests/ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests.csproj
@@ -7,6 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="MongoDB.Driver" Version="2.11.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
@@ -23,6 +26,12 @@
   <ItemGroup>
     <ProjectReference Include="..\ChustaSoft.Tools.DBAccess.Abstractions\ChustaSoft.Tools.DBAccess.Abstractions.csproj" />
     <ProjectReference Include="..\ChustaSoft.Tools.DBAccess.MongoDb\ChustaSoft.Tools.DBAccess.MongoDb.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests/KeyResolvers/IdPropertyKeyResolverTests.cs
+++ b/ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests/KeyResolvers/IdPropertyKeyResolverTests.cs
@@ -1,0 +1,51 @@
+﻿using ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests.Base;
+using ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests.Models;
+using Xunit;
+
+namespace ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests
+{
+    public class IdPropertyKeyResolverTests : MongoDbIntegrationTestBase
+    {
+        private readonly IUnitOfWork<string> unitOfWork;
+
+        public IdPropertyKeyResolverTests() : base()
+        {
+            var testContext = new MongoContext(configuration, new IdPropertyKeyResolver());
+            unitOfWork = new UnitOfWork<MongoContext, string>(testContext);
+        }
+
+        private readonly CountryWithIdProperty france  = new CountryWithIdProperty { Id = "F", Name = "France" };
+        private readonly CountryWithIdProperty netherlands  = new CountryWithIdProperty { Id = "NL", Name = "The Netherlands" };
+
+        [Fact]
+        public void Given_UnitOfWork_When_GetSyncRepository_Then_CanUpdateEntity()
+        {
+            // Arrange
+            var syncRepository = unitOfWork.GetRepository<CountryWithIdProperty>();
+            InsertCountries(france, netherlands);
+
+            // Act
+            france.Name = "République française";
+            netherlands.Name = "Koninkrijk der Nederlanden";
+            syncRepository.Update(france);
+
+            // Assert
+            var currentFrance = syncRepository.GetSingle(france.Id);
+            var currentNeherlands = syncRepository.GetSingle(netherlands.Id);
+
+            Assert.Equal("République française", currentFrance.Name);
+            Assert.Equal("The Netherlands", currentNeherlands.Name);
+        }
+
+        /// <summary>
+        /// Inserts given countries and commits transaction
+        /// </summary>
+        /// <param name="countries"></param>
+        private void InsertCountries(params CountryWithIdProperty[] countries)
+        {
+            var syncRepository = unitOfWork.GetRepository<CountryWithIdProperty>();
+            syncRepository.Insert(countries);
+            unitOfWork.CommitTransaction();
+        }
+    }
+}

--- a/ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests/KeyResolvers/MongoKeyResolverTests.cs
+++ b/ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests/KeyResolvers/MongoKeyResolverTests.cs
@@ -1,0 +1,51 @@
+﻿using ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests.Base;
+using ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests.Models;
+using Xunit;
+
+namespace ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests
+{
+    public class MongoKeyResolverTests : MongoDbIntegrationTestBase
+    {
+        private readonly IUnitOfWork<int> unitOfWork;
+
+        public MongoKeyResolverTests() : base()
+        {
+            var testContext = new MongoContext(configuration, new MongoKeyResolver());
+            unitOfWork = new UnitOfWork<MongoContext, int>(testContext);
+        }
+
+        private readonly CountryWithMongoId france  = new CountryWithMongoId { WeirdId = 3, Name = "France" };
+        private readonly CountryWithMongoId netherlands  = new CountryWithMongoId { WeirdId = 4, Name = "The Netherlands" };
+
+        [Fact]
+        public void Given_UnitOfWork_When_GetSyncRepository_Then_CanUpdateEntity()
+        {
+            // Arrange
+            var syncRepository = unitOfWork.GetRepository<CountryWithMongoId>();
+            InsertCountries(france, netherlands);
+
+            // Act
+            france.Name = "République française";
+            netherlands.Name = "Koninkrijk der Nederlanden";
+            syncRepository.Update(france);
+
+            // Assert
+            var currentFrance = syncRepository.GetSingle(france.WeirdId);
+            var currentNeherlands = syncRepository.GetSingle(netherlands.WeirdId);
+
+            Assert.Equal("République française", currentFrance.Name);
+            Assert.Equal("The Netherlands", currentNeherlands.Name);
+        }
+
+        /// <summary>
+        /// Inserts given countries and commits transaction
+        /// </summary>
+        /// <param name="countries"></param>
+        private void InsertCountries(params CountryWithMongoId[] countries)
+        {
+            var syncRepository = unitOfWork.GetRepository<CountryWithMongoId>();
+            syncRepository.Insert(countries);
+            unitOfWork.CommitTransaction();
+        }
+    }
+}

--- a/ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests/Models/Country.cs
+++ b/ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests/Models/Country.cs
@@ -1,10 +1,11 @@
 ﻿using ChustaSoft.Common.Contracts;
+using System;
 
 namespace ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests.Models
 {
-    public class Country : IKeyable<string>
+    public class Country : IKeyable<Guid>
     {
-        public string Id { get; set; }
+        public Guid Id { get; set; }
         public string Name { get; set; }
     }
 }

--- a/ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests/Models/CountryWithIdProperty.cs
+++ b/ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests/Models/CountryWithIdProperty.cs
@@ -1,0 +1,8 @@
+﻿namespace ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests.Models
+{
+    public class CountryWithIdProperty
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests/Models/CountryWithMongoId.cs
+++ b/ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests/Models/CountryWithMongoId.cs
@@ -1,0 +1,11 @@
+﻿using MongoDB.Bson.Serialization.Attributes;
+
+namespace ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests.Models
+{
+    public class CountryWithMongoId
+    {
+        [BsonId]
+        public int WeirdId { get; set; }
+        public string Name { get; set; }
+    }
+}

--- a/ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests/MongoDbRepositoryTests.cs
+++ b/ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests/MongoDbRepositoryTests.cs
@@ -6,10 +6,10 @@ using Xunit;
 
 namespace ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests
 {
-    public class RepositoryTests : IntegrationTestBase
+    public class MongoDbRepositoryTests : MongoDbIntegrationTestBase
     {
 
-        public RepositoryTests() 
+        public MongoDbRepositoryTests() 
             : base()
         {}
 

--- a/ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests/MongoDbRepositoryTests.cs
+++ b/ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests/MongoDbRepositoryTests.cs
@@ -194,6 +194,25 @@ namespace ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests
             Assert.Equal(belgium.Id, belgiumRetrieved.Id);
         }
 
+        [Fact]
+        public void Given_UnitOfWork_When_GetSyncRepository_Then_CanReturnQueryables()
+        {
+            // Arrange
+            var syncRepository = unitOfWork.GetRepository<Country>();
+
+            InsertCountries(france, belgium, netherlands, sweden, switserland);
+
+            // Act
+            var countriesWithS = syncRepository.Query
+                .Where(c => c.Name.StartsWith("Sw"))
+                .Select(c => c.Name)
+                .Take(1);
+
+            // Assert
+            Assert.Equal(1, countriesWithS.Count());
+            Assert.Equal(new[] { "Sweden" }, countriesWithS);
+        }
+
         /// <summary>
         /// Inserts given countries and commits transaction
         /// </summary>

--- a/ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests/MongoDbRepositoryTests.cs
+++ b/ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests/MongoDbRepositoryTests.cs
@@ -8,10 +8,13 @@ namespace ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests
 {
     public class MongoDbRepositoryTests : MongoDbIntegrationTestBase
     {
+        private  readonly IUnitOfWork unitOfWork;
 
-        public MongoDbRepositoryTests() 
-            : base()
-        {}
+        public MongoDbRepositoryTests() : base()
+        {
+            var testContext = new MongoContext(configuration);
+            unitOfWork = new UnitOfWork<MongoContext>(testContext);
+        }
 
         private readonly Country france  = new Country { Id = Guid.NewGuid(), Name = "France" };
         private readonly Country belgium  = new Country { Id = Guid.NewGuid(), Name = "Belgium" };

--- a/ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests/RepositoryTests.cs
+++ b/ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests/RepositoryTests.cs
@@ -1,5 +1,7 @@
 ﻿using ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests.Base;
 using ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests.Models;
+using System;
+using System.Linq;
 using Xunit;
 
 namespace ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests
@@ -10,6 +12,12 @@ namespace ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests
         public RepositoryTests() 
             : base()
         {}
+
+        private readonly Country france  = new Country { Id = Guid.NewGuid(), Name = "France" };
+        private readonly Country belgium  = new Country { Id = Guid.NewGuid(), Name = "Belgium" };
+        private readonly Country netherlands  = new Country { Id = Guid.NewGuid(), Name = "The Netherlands" };
+        private readonly Country sweden = new Country { Id = Guid.NewGuid(), Name = "Sweden" };
+        private readonly Country switserland = new Country { Id = Guid.NewGuid(), Name = "Switserland" };
 
 
         [Fact]
@@ -36,6 +44,165 @@ namespace ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests
 
             Assert.NotNull(syncRepository);
             Assert.NotNull(asyncRepository);
+        }
+
+        [Fact]
+        public void Given_UnitOfWork_When_GetSyncRepository_Then_CanInsertAndRetrieveEntity()
+        {
+            // Arrange
+            var syncRepository = unitOfWork.GetRepository<Country>();
+
+            // Act
+            InsertCountries(france);
+            var retrievedCountry = syncRepository.GetSingle(france.Id);
+
+            // Assert
+            Assert.Equal(france.Id, retrievedCountry.Id);
+            Assert.Equal(france.Name, retrievedCountry.Name);
+        }
+
+        [Fact]
+        public void Given_UnitOfWork_When_GetSyncRepository_Then_CanInsertMultipleEntities()
+        {
+            // Arrange
+            var syncRepository = unitOfWork.GetRepository<Country>();
+
+            // Act
+            InsertCountries(france, belgium);
+
+            // Assert
+            var franceRetrieved = syncRepository.GetSingle(france.Id);
+            var belgiumRetrieved = syncRepository.GetSingle(belgium.Id);
+
+            Assert.Equal(france.Id, franceRetrieved.Id);
+            Assert.Equal(france.Name, franceRetrieved.Name);
+            Assert.Equal(belgium.Id, belgiumRetrieved.Id);
+            Assert.Equal(belgium.Name, belgiumRetrieved.Name);
+        }
+
+        [Fact]
+        public void Given_UnitOfWork_When_GetSyncRepository_Then_CanGetEntityBasedOnFilter()
+        {
+            // Arrange
+            InsertCountries(france, belgium);
+            var syncRepository = unitOfWork.GetRepository<Country>();
+
+            // Act
+            var belgiumRetrieved = syncRepository.GetSingle(x => x.FilterBy(c => c.Name == "Belgium"));
+
+            // Assert
+            Assert.Equal(belgium.Id, belgiumRetrieved.Id);
+            Assert.Equal(belgium.Name, belgiumRetrieved.Name);
+        }
+
+        [Fact]
+        public void Given_UnitOfWork_When_GetSyncRepository_Then_CanGetEntitiesBasedOnFilter()
+        {
+            // Arrange
+            var syncRepository = unitOfWork.GetRepository<Country>();
+
+            InsertCountries(france, belgium, netherlands, sweden, switserland);
+
+            // Act
+            var countriesWithS = syncRepository.GetMultiple(x => x.FilterBy(c => c.Name.StartsWith("S")));
+
+            // Assert
+            Assert.Equal(2, countriesWithS.Count());
+            Assert.Equal(new[] { "Sweden", "Switserland" }, countriesWithS.Select(c => c.Name));
+        }
+
+        [Fact]
+        public void Given_UnitOfWork_When_GetSyncRepository_Then_CanUpdateEntity()
+        {
+            // Arrange
+            var syncRepository = unitOfWork.GetRepository<Country>();
+            InsertCountries(france, netherlands);
+
+            // Act
+            france.Name = "République française";
+            netherlands.Name = "Koninkrijk der Nederlanden";
+            syncRepository.Update(france);
+
+            // Assert
+            var franceByOriginalName = syncRepository.GetSingle(x => x.FilterBy(c => c.Name == "France"));
+            var franceByNewName = syncRepository.GetSingle(x => x.FilterBy(c => c.Name == "République française"));
+            var unmodifiedCountry = syncRepository.GetSingle(netherlands.Id);
+
+            Assert.Null(franceByOriginalName);
+            Assert.Equal(france.Id, franceByNewName.Id);
+            Assert.Equal("The Netherlands", unmodifiedCountry.Name);
+        }
+
+        [Fact]
+        public void Given_UnitOfWork_When_GetSyncRepository_Then_CanUpdateMultipleEntity()
+        {
+            // Arrange
+            var syncRepository = unitOfWork.GetRepository<Country>();
+
+            InsertCountries(france, belgium, netherlands);
+
+            // Act
+            france.Name = "République française";
+            belgium.Name = "Koninkrijk België";
+            syncRepository.Update(new Country[] { france, belgium });
+
+            // Assert
+            var franceRetrievedAfterChange = syncRepository.GetSingle(france.Id);
+            var belgiumRetrievedAfterChange = syncRepository.GetSingle(belgium.Id);
+            var netherlandsRetrieved = syncRepository.GetSingle(netherlands.Id);
+
+            Assert.Equal("République française", franceRetrievedAfterChange.Name);
+            Assert.Equal("Koninkrijk België", belgiumRetrievedAfterChange.Name);
+            Assert.Equal("The Netherlands", netherlandsRetrieved.Name);
+        }
+
+        [Fact]
+        public void Given_UnitOfWork_When_GetSyncRepository_Then_CanDeleteEntityById()
+        {
+            // Arrange
+            var syncRepository = unitOfWork.GetRepository<Country>();
+
+            InsertCountries(france, belgium);
+
+            // Act
+            syncRepository.Delete(france.Id);
+
+            // Assert
+            var franceRetrieved = syncRepository.GetSingle(france.Id);
+            var belgiumRetrieved = syncRepository.GetSingle(belgium.Id);
+
+            Assert.Null(franceRetrieved);
+            Assert.Equal(belgium.Id, belgiumRetrieved.Id);
+        }
+
+        [Fact]
+        public void Given_UnitOfWork_When_GetSyncRepository_Then_CanDeleteEntity()
+        {
+            // Arrange
+            var syncRepository = unitOfWork.GetRepository<Country>();
+
+            InsertCountries(france, belgium);
+
+            // Act
+            syncRepository.Delete(france);
+
+            // Assert
+            var franceRetrieved = syncRepository.GetSingle(france.Id);
+            var belgiumRetrieved = syncRepository.GetSingle(belgium.Id);
+
+            Assert.Null(franceRetrieved);
+            Assert.Equal(belgium.Id, belgiumRetrieved.Id);
+        }
+
+        /// <summary>
+        /// Inserts given countries and commits transaction
+        /// </summary>
+        /// <param name="countries"></param>
+        private void InsertCountries(params Country[] countries)
+        {
+            var syncRepository = unitOfWork.GetRepository<Country>();
+            syncRepository.Insert(countries);
+            unitOfWork.CommitTransaction();
         }
     }
 }

--- a/ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests/appsettings.json
+++ b/ChustaSoft.Tools.DBAccess.MongoDb.IntegrationTests/appsettings.json
@@ -1,0 +1,6 @@
+﻿{
+  "MongoDatabaseConfiguration": {
+    "ConnectionString": "mongodb://localhost:27017",
+    "DatabaseName": "ChustaSoftIntegrationTestDb"
+  }
+}

--- a/ChustaSoft.Tools.DBAccess.MongoDb.UnitTests/ChustaSoft.Tools.DBAccess.MongoDb.UnitTests.csproj
+++ b/ChustaSoft.Tools.DBAccess.MongoDb.UnitTests/ChustaSoft.Tools.DBAccess.MongoDb.UnitTests.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ChustaSoft.Tools.DBAccess.MongoDb\ChustaSoft.Tools.DBAccess.MongoDb.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/ChustaSoft.Tools.DBAccess.MongoDb.UnitTests/KeyResolvers/DefaultKeyResolverTests.cs
+++ b/ChustaSoft.Tools.DBAccess.MongoDb.UnitTests/KeyResolvers/DefaultKeyResolverTests.cs
@@ -1,0 +1,57 @@
+using ChustaSoft.Common.Contracts;
+using System;
+using Xunit;
+
+namespace ChustaSoft.Tools.DBAccess.MongoDb.UnitTests
+{
+    public class DefaultKeyResolverTests
+    {
+        public DefaultKeyResolverTests()
+        {
+        }
+
+        [Fact]
+        public void Given_Entity_When_Keyable_Then_ItShouldRetrieveTheKey()
+        {
+            // Arrange
+            var resolver = new DefaultKeyResolver();
+            var entity = new KeyableCountry { Id = Guid.NewGuid() , Name = "France" };
+
+            // Act
+            var id = resolver.GetKey<KeyableCountry, Guid>(entity);
+
+            // Assert
+            Assert.Equal(entity.Id, id);
+        }
+
+        [Fact]
+        public void Given_Entity_When_NotKeyable_Then_ItShouldThrow()
+        {
+            // Arrange
+            var resolver = new DefaultKeyResolver();
+            var entity = new NonKeyableCountry { Id = Guid.NewGuid() , Name = "France" };
+
+            // Act
+            var exception = Assert.Throws<InvalidOperationException>(
+                () => resolver.GetKey<NonKeyableCountry, Guid>(entity)
+            );
+
+            // Assert
+            var message = "Type 'ChustaSoft.Tools.DBAccess.MongoDb.UnitTests.DefaultKeyResolverTests+NonKeyableCountry' does not implement IKeyable. Please register an implementation of IKeyResolver that can process this type";
+            Assert.Equal(message, exception.Message);
+        }
+
+        private class KeyableCountry : IKeyable<Guid>
+        {
+            public Guid Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        private class NonKeyableCountry
+        {
+            public Guid Id { get; set; }
+            public string Name { get; set; }
+        }
+    }
+
+}

--- a/ChustaSoft.Tools.DBAccess.MongoDb.UnitTests/KeyResolvers/IdPropertyKeyResolverTests.cs
+++ b/ChustaSoft.Tools.DBAccess.MongoDb.UnitTests/KeyResolvers/IdPropertyKeyResolverTests.cs
@@ -1,0 +1,92 @@
+using System;
+using Xunit;
+
+namespace ChustaSoft.Tools.DBAccess.MongoDb.UnitTests
+{
+    public class IdPropertyKeyResolverTests
+    {
+        public IdPropertyKeyResolverTests()
+        {
+        }
+
+        [Fact]
+        public void Given_Entity_When_ItHasAnId_Then_ItShouldRetrieveTheKey()
+        {
+            // Arrange
+            var resolver = new IdPropertyKeyResolver();
+            var entity = new Country { Id = 4 , Name = "France" };
+
+            // Act
+            var id = resolver.GetKey<Country, int>(entity);
+
+            // Assert
+            Assert.Equal(4, id);
+        }
+
+        [Fact]
+        public void Given_Entity_When_IdIsDefault_Then_ItShouldRetrieveDefault()
+        {
+            // Arrange
+            var resolver = new IdPropertyKeyResolver();
+            var entity = new Country { Name = "France" };
+
+            // Act
+            var id = resolver.GetKey<Country, int>(entity);
+
+            // Assert
+            Assert.Equal(0, id);
+        }
+
+        [Fact]
+        public void Given_Entity_When_DoesNotHaveId_Then_ItShouldThrow()
+        {
+            // Arrange
+            var resolver = new IdPropertyKeyResolver();
+            var entity = new CountryWithoutId { Name = "France" };
+
+            // Act
+            var exception = Assert.Throws<InvalidOperationException>(
+                () => resolver.GetKey<CountryWithoutId, Guid>(entity)
+            );
+
+            // Assert
+            var message = "Type 'ChustaSoft.Tools.DBAccess.MongoDb.UnitTests.CountryWithoutId' does not have an Id property. Please register an implementation of IKeyResolver that can process this type";
+            Assert.Equal(message, exception.Message);
+        }
+
+        [Fact]
+        public void Given_Entity_When_HasWrongIdType_Then_ItShouldThrow()
+        {
+            // Arrange
+            var resolver = new IdPropertyKeyResolver();
+            var entity = new CountryWithWrongIdType { Id = "F", Name = "France" };
+
+            // Act
+            var exception = Assert.Throws<InvalidOperationException>(
+                () => resolver.GetKey<CountryWithWrongIdType, Guid>(entity)
+            );
+
+            // Assert
+            var message = "Type 'ChustaSoft.Tools.DBAccess.MongoDb.UnitTests.CountryWithWrongIdType' has an Id property, but it is not of the expected type. Please register an implementation of IKeyResolver that can process this type";
+            Assert.Equal(message, exception.Message);
+        }
+    }
+
+    public class Country
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    public class CountryWithWrongIdType
+    {
+        public string Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    public class CountryWithoutId
+    {
+        public string Name { get; set; }
+    }
+
+}

--- a/ChustaSoft.Tools.DBAccess.MongoDb.UnitTests/KeyResolvers/MongoKeyResolverTest.cs
+++ b/ChustaSoft.Tools.DBAccess.MongoDb.UnitTests/KeyResolvers/MongoKeyResolverTest.cs
@@ -1,0 +1,79 @@
+using MongoDB.Bson.Serialization.Attributes;
+using System;
+using Xunit;
+
+namespace ChustaSoft.Tools.DBAccess.MongoDb.UnitTests
+{
+    public class MongoKeyResolverTests
+    {
+        public MongoKeyResolverTests()
+        {
+        }
+
+        [Fact]
+        public void Given_Entity_When_BsonIdAttributePresent_Then_ItShouldRetrieveTheKey()
+        {
+            // Arrange
+            var resolver = new MongoKeyResolver();
+            var entity = new BsonIdCountry { OtherIdProperty = 3, Name = "France" };
+
+            // Act
+            var id = resolver.GetKey<BsonIdCountry, int>(entity);
+
+            // Assert
+            Assert.Equal(3, id);
+        }
+
+        [Fact]
+        public void Given_Entity_When_BsonIdAttributePresentOnField_Then_ItShouldRetrieveTheKey()
+        {
+            // Arrange
+            var resolver = new MongoKeyResolver();
+            var entity = new BsonIdOnFieldCountry { OtherIdField = 3, Name = "France" };
+
+            // Act
+            var id = resolver.GetKey<BsonIdOnFieldCountry, int>(entity);
+
+            // Assert
+            Assert.Equal(3, id);
+        }
+
+        [Fact]
+        public void Given_Entity_When_BsonIdAttributeNotPresent_Then_ItShouldThrow()
+        {
+            // Arrange
+            var resolver = new MongoKeyResolver();
+            var entity = new NoBsonIdCountry { OtherIdProperty = 3, Name = "France" };
+
+            // Act
+            var exception = Assert.Throws<InvalidOperationException>(
+                () => resolver.GetKey<NoBsonIdCountry, int>(entity)
+            );
+
+            // Assert
+            var message = "Type 'ChustaSoft.Tools.DBAccess.MongoDb.UnitTests.MongoKeyResolverTests+NoBsonIdCountry' does not contain a property marked with the BsonId attribute. Please register an implementation of IKeyResolver that can process this type";
+            Assert.Equal(message, exception.Message);
+        }
+
+        private class BsonIdCountry
+        {
+            [BsonId]
+            public int OtherIdProperty { get; set; }
+            public string Name { get; set; }
+        }
+
+        private class BsonIdOnFieldCountry
+        {
+            [BsonId]
+            public int OtherIdField;
+            public string Name { get; set; }
+        }
+
+        private class NoBsonIdCountry
+        {
+            public int OtherIdProperty { get; set; }
+            public string Name { get; set; }
+        }
+    }
+
+}

--- a/ChustaSoft.Tools.DBAccess.MongoDb/ChustaSoft.Tools.DBAccess.MongoDb.csproj
+++ b/ChustaSoft.Tools.DBAccess.MongoDb/ChustaSoft.Tools.DBAccess.MongoDb.csproj
@@ -22,6 +22,7 @@
 
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="MongoDB.Driver" Version="2.11.2" />
   </ItemGroup>
   

--- a/ChustaSoft.Tools.DBAccess.MongoDb/IMongoContext.cs
+++ b/ChustaSoft.Tools.DBAccess.MongoDb/IMongoContext.cs
@@ -10,5 +10,6 @@ namespace ChustaSoft.Tools.DBAccess
         IMongoCollection<T> GetCollection<T>();
         IMongoCollection<T> GetCollection<T>(string name);
         Task<int> SaveChangesAsync();
+        IKeyResolver KeyResolver { get; }
     }
 }

--- a/ChustaSoft.Tools.DBAccess.MongoDb/KeyResolvers/DefaultKeyResolver.cs
+++ b/ChustaSoft.Tools.DBAccess.MongoDb/KeyResolvers/DefaultKeyResolver.cs
@@ -1,0 +1,23 @@
+﻿using ChustaSoft.Common.Contracts;
+using System;
+
+namespace ChustaSoft.Tools.DBAccess
+{
+    public class DefaultKeyResolver : IKeyResolver
+    {
+        public TKey GetKey<TEntity, TKey>(TEntity entity)
+        {
+            var keyable = entity
+                as IKeyable<TKey>
+                ?? throw CreateIsNotKeyableException<TEntity, TKey>(entity);
+
+            return keyable.Id;
+        }
+
+        private InvalidOperationException CreateIsNotKeyableException<TEntity, TKey>(TEntity entity)
+        {
+            var message = $"Type '{entity.GetType()}' does not implement {nameof(IKeyable<TKey>)}. Please register an implementation of {nameof(IKeyResolver)} that can process this type";
+            return new InvalidOperationException(message);
+        }
+    }
+}

--- a/ChustaSoft.Tools.DBAccess.MongoDb/KeyResolvers/IKeyResolver.cs
+++ b/ChustaSoft.Tools.DBAccess.MongoDb/KeyResolvers/IKeyResolver.cs
@@ -1,0 +1,7 @@
+﻿namespace ChustaSoft.Tools.DBAccess
+{
+    public interface IKeyResolver
+    {
+        TKey GetKey<TEntity, TKey>(TEntity entity);
+    }
+}

--- a/ChustaSoft.Tools.DBAccess.MongoDb/KeyResolvers/IdPropertyKeyResolver.cs
+++ b/ChustaSoft.Tools.DBAccess.MongoDb/KeyResolvers/IdPropertyKeyResolver.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.CSharp.RuntimeBinder;
+using System;
+
+namespace ChustaSoft.Tools.DBAccess
+{
+    public class IdPropertyKeyResolver : IKeyResolver
+    {
+        public TKey GetKey<TEntity, TKey>(TEntity entity)
+        {
+            dynamic dynamicEntity = entity;
+
+            try
+            {
+                object id = dynamicEntity.Id;
+                return (TKey)id;
+            }
+            catch (RuntimeBinderException exception)
+            {
+
+                var message = $"Type '{entity.GetType()}' does not have an Id property. Please register an implementation of {nameof(IKeyResolver)} that can process this type";
+                throw new InvalidOperationException(message, exception);
+            }
+            catch (InvalidCastException exception)
+            {
+
+                var message = $"Type '{entity.GetType()}' has an Id property, but it is not of the expected type. Please register an implementation of IKeyResolver that can process this type";
+                throw new InvalidOperationException(message, exception);
+            }
+        }
+    }
+}

--- a/ChustaSoft.Tools.DBAccess.MongoDb/KeyResolvers/IdPropertyKeyResolver.cs
+++ b/ChustaSoft.Tools.DBAccess.MongoDb/KeyResolvers/IdPropertyKeyResolver.cs
@@ -16,14 +16,12 @@ namespace ChustaSoft.Tools.DBAccess
             }
             catch (RuntimeBinderException exception)
             {
-
                 var message = $"Type '{entity.GetType()}' does not have an Id property. Please register an implementation of {nameof(IKeyResolver)} that can process this type";
                 throw new InvalidOperationException(message, exception);
             }
             catch (InvalidCastException exception)
             {
-
-                var message = $"Type '{entity.GetType()}' has an Id property, but it is not of the expected type. Please register an implementation of IKeyResolver that can process this type";
+                var message = $"Type '{entity.GetType()}' has an Id property, but it is not of the expected type. Please register an implementation of {nameof(IKeyResolver)} that can process this type";
                 throw new InvalidOperationException(message, exception);
             }
         }

--- a/ChustaSoft.Tools.DBAccess.MongoDb/KeyResolvers/MongoKeyResolver.cs
+++ b/ChustaSoft.Tools.DBAccess.MongoDb/KeyResolvers/MongoKeyResolver.cs
@@ -35,7 +35,7 @@ namespace ChustaSoft.Tools.DBAccess
 
         private Exception NoAttributeFoundMessage<TEntity>(TEntity entity)
         {
-            var message = $"Type '{entity.GetType()}' does not contain a property marked with the BsonId attribute. Please register an implementation of IKeyResolver that can process this type";
+            var message = $"Type '{entity.GetType()}' does not contain a property marked with the BsonId attribute. Please register an implementation of {nameof(IKeyResolver)} that can process this type";
             return new InvalidOperationException(message);
         }
     }

--- a/ChustaSoft.Tools.DBAccess.MongoDb/KeyResolvers/MongoKeyResolver.cs
+++ b/ChustaSoft.Tools.DBAccess.MongoDb/KeyResolvers/MongoKeyResolver.cs
@@ -1,0 +1,42 @@
+﻿using MongoDB.Bson.Serialization.Attributes;
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace ChustaSoft.Tools.DBAccess
+{
+    public class MongoKeyResolver : IKeyResolver
+    {
+        public TKey GetKey<TEntity, TKey>(TEntity entity)
+        {
+            var memberWithBsonIdAttribute = entity
+                .GetType()
+                .GetMembers()
+                .FirstOrDefault(m => Attribute.IsDefined(m, typeof(BsonIdAttribute)));
+            
+            if (memberWithBsonIdAttribute == null)
+                throw NoAttributeFoundMessage(entity);
+            else
+                return GetValue<TEntity, TKey>(memberWithBsonIdAttribute, entity);
+        }
+
+        private TKey GetValue<TEntity, TKey>(MemberInfo memberWithBsonIdAttribute, TEntity entity)
+        {
+            switch (memberWithBsonIdAttribute)
+            {
+                case PropertyInfo propertyWithBsonIdAttribute:
+                    return (TKey)propertyWithBsonIdAttribute.GetValue(entity);
+                case FieldInfo fieldWithBsonIdAttribute:
+                    return (TKey)fieldWithBsonIdAttribute.GetValue(entity);
+                default:
+                    throw NoAttributeFoundMessage(entity);
+            }
+        }
+
+        private Exception NoAttributeFoundMessage<TEntity>(TEntity entity)
+        {
+            var message = $"Type '{entity.GetType()}' does not contain a property marked with the BsonId attribute. Please register an implementation of IKeyResolver that can process this type";
+            return new InvalidOperationException(message);
+        }
+    }
+}

--- a/ChustaSoft.Tools.DBAccess.MongoDb/MongoContext.cs
+++ b/ChustaSoft.Tools.DBAccess.MongoDb/MongoContext.cs
@@ -17,13 +17,14 @@ namespace ChustaSoft.Tools.DBAccess
         private readonly ICollection<Func<Task>> _commands;
         private readonly IMongoDatabase _database;
         private readonly MongoClient _mongoClient;
-
         private IClientSessionHandle _session;
 
+        public IKeyResolver KeyResolver { get; private set; }
 
-        public MongoContext(IDatabaseConfiguration dbConfiguration)
+        public MongoContext(IDatabaseConfiguration dbConfiguration, IKeyResolver keyResolver = null)
         {
             _commands = new List<Func<Task>>();
+            KeyResolver = keyResolver ?? new DefaultKeyResolver();
 
             RegisterConventions();
 

--- a/ChustaSoft.Tools.DBAccess.MongoDb/MongoDatabaseConfiguration.cs
+++ b/ChustaSoft.Tools.DBAccess.MongoDb/MongoDatabaseConfiguration.cs
@@ -12,5 +12,9 @@
             DatabaseName = databaseName;
         }
 
+        public MongoDatabaseConfiguration()
+        {
+        }
+
     }
 }

--- a/ChustaSoft.Tools.DBAccess.MongoDb/MongoDatabaseConfiguration.cs
+++ b/ChustaSoft.Tools.DBAccess.MongoDb/MongoDatabaseConfiguration.cs
@@ -6,11 +6,10 @@
 
         public string DatabaseName { get; set; }
 
-
         public MongoDatabaseConfiguration(string connectionString, string databaseName)
         {
-            this.ConnectionString = connectionString;
-            this.DatabaseName = databaseName;
+            ConnectionString = connectionString;
+            DatabaseName = databaseName;
         }
 
     }

--- a/ChustaSoft.Tools.DBAccess.MongoDb/Repository.cs
+++ b/ChustaSoft.Tools.DBAccess.MongoDb/Repository.cs
@@ -11,7 +11,7 @@ namespace ChustaSoft.Tools.DBAccess
     {
         private readonly IMongoCollection<TEntity> _dbSet;
 
-        public IQueryable<TEntity> Query => throw new NotImplementedException();
+        public IQueryable<TEntity> Query => GetQueryable();
 
         public Repository(IMongoContext context) 
             : base(context)

--- a/ChustaSoft.Tools.DBAccess.MongoDb/Repository.cs
+++ b/ChustaSoft.Tools.DBAccess.MongoDb/Repository.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using ChustaSoft.Common.Contracts;
+using MongoDB.Driver;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -7,66 +9,87 @@ namespace ChustaSoft.Tools.DBAccess
     public class Repository<TEntity, TKey> : RepositoryBase<IMongoContext, TEntity>, IRepository<TEntity, TKey>
         where TEntity : class
     {
+        private readonly IMongoCollection<TEntity> _dbSet;
 
         public IQueryable<TEntity> Query => throw new NotImplementedException();
 
 
         public Repository(IMongoContext context) 
             : base(context)
-        { }
-
-
+        {
+            _dbSet = context.GetCollection<TEntity>();
+        }
 
         public TEntity GetSingle(TKey id)
         {
-            throw new NotImplementedException();
+            var idFilter = CreateIdFilter(id);
+
+            return _dbSet
+                .Find(idFilter)
+                .FirstOrDefault();
         }
 
         public TEntity GetSingle(Action<ISingleResultSearchParametersBuilder<TEntity>> searchCriteria)
         {
-            throw new NotImplementedException();
+            var searchParams = MongoSearchParametersBuilder<TEntity, MongoSearchParameters<TEntity>>.GetParametersFromCriteria(searchCriteria);
+
+            return _dbSet.Find(searchParams.Filter).FirstOrDefault();
         }
 
         public IEnumerable<TEntity> GetMultiple(Action<ISearchParametersBuilder<TEntity>> searchCriteria)
         {
-            throw new NotImplementedException();
+            var searchParams = MongoSearchParametersBuilder<TEntity, MongoSearchParameters<TEntity>>.GetParametersFromCriteria(searchCriteria);
+
+            return _dbSet.Find(searchParams.Filter).ToList();
         }
 
         public void Insert(TEntity entity)
         {
-            throw new NotImplementedException();
+            _dbSet.InsertOne(entity);
         }
 
         public void Insert(IEnumerable<TEntity> entities)
         {
-            throw new NotImplementedException();
+            _dbSet.InsertMany(entities);
         }
 
         public void Update(TEntity entity)
         {
-            throw new NotImplementedException();
+            var idFilter = CreateIdFilter(entity.Id);
+
+            _dbSet.ReplaceOne(idFilter, entity);
         }
 
         public void Update(IEnumerable<TEntity> entities)
         {
-            throw new NotImplementedException();
+            foreach (var entity in entities)
+            {
+                Update(entity);
+            }
         }
 
         public void Delete(TKey id)
         {
-            throw new NotImplementedException();
+            var idFilter = CreateIdFilter(id);
+
+            _dbSet.DeleteOne(idFilter);
         }
 
         public void Delete(TEntity entity)
         {
-            throw new NotImplementedException();
+            var idFilter = CreateIdFilter(entity.Id);
+
+            _dbSet.DeleteOne(idFilter);
         }
 
 
         protected override IQueryable<TEntity> GetQueryable()
         {
-            throw new NotImplementedException();
+            return _dbSet.AsQueryable();
         }
+
+        private FilterDefinition<TEntity> CreateIdFilter<T>(T id)
+            => Builders<TEntity>.Filter.Eq("_id", id);
 
     }
 

--- a/ChustaSoft.Tools.DBAccess.MongoDb/Repository.cs
+++ b/ChustaSoft.Tools.DBAccess.MongoDb/Repository.cs
@@ -13,7 +13,6 @@ namespace ChustaSoft.Tools.DBAccess
 
         public IQueryable<TEntity> Query => throw new NotImplementedException();
 
-
         public Repository(IMongoContext context) 
             : base(context)
         {
@@ -31,14 +30,14 @@ namespace ChustaSoft.Tools.DBAccess
 
         public TEntity GetSingle(Action<ISingleResultSearchParametersBuilder<TEntity>> searchCriteria)
         {
-            var searchParams = MongoSearchParametersBuilder<TEntity, MongoSearchParameters<TEntity>>.GetParametersFromCriteria(searchCriteria);
+            var searchParams = CreateSearchParameters(searchCriteria);
 
             return _dbSet.Find(searchParams.Filter).FirstOrDefault();
         }
 
         public IEnumerable<TEntity> GetMultiple(Action<ISearchParametersBuilder<TEntity>> searchCriteria)
         {
-            var searchParams = MongoSearchParametersBuilder<TEntity, MongoSearchParameters<TEntity>>.GetParametersFromCriteria(searchCriteria);
+            var searchParams = CreateSearchParameters(searchCriteria);
 
             return _dbSet.Find(searchParams.Filter).ToList();
         }
@@ -90,6 +89,11 @@ namespace ChustaSoft.Tools.DBAccess
 
         private FilterDefinition<TEntity> CreateIdFilter<T>(T id)
             => Builders<TEntity>.Filter.Eq("_id", id);
+
+        private MongoSearchParameters<TEntity> CreateSearchParameters(Action<ISearchParametersBuilder<TEntity>> searchCriteria)
+        {
+            return MongoSearchParametersBuilder<TEntity, MongoSearchParameters<TEntity>>.GetParametersFromCriteria(searchCriteria);
+        }
 
     }
 

--- a/ChustaSoft.Tools.DBAccess.MongoDb/Repository.cs
+++ b/ChustaSoft.Tools.DBAccess.MongoDb/Repository.cs
@@ -21,7 +21,7 @@ namespace ChustaSoft.Tools.DBAccess
 
         public TEntity GetSingle(TKey id)
         {
-            var idFilter = CreateIdFilter(id);
+            var idFilter = CreateFilter(id);
 
             return _dbSet
                 .Find(idFilter)
@@ -54,7 +54,7 @@ namespace ChustaSoft.Tools.DBAccess
 
         public void Update(TEntity entity)
         {
-            var idFilter = CreateIdFilter(entity.Id);
+            var idFilter = CreateFilter(entity.Id);
 
             _dbSet.ReplaceOne(idFilter, entity);
         }
@@ -69,14 +69,14 @@ namespace ChustaSoft.Tools.DBAccess
 
         public void Delete(TKey id)
         {
-            var idFilter = CreateIdFilter(id);
+            var idFilter = CreateFilter(id);
 
             _dbSet.DeleteOne(idFilter);
         }
 
         public void Delete(TEntity entity)
         {
-            var idFilter = CreateIdFilter(entity.Id);
+            var idFilter = CreateFilter(entity.Id);
 
             _dbSet.DeleteOne(idFilter);
         }
@@ -87,7 +87,7 @@ namespace ChustaSoft.Tools.DBAccess
             return _dbSet.AsQueryable();
         }
 
-        private FilterDefinition<TEntity> CreateIdFilter<T>(T id)
+        private FilterDefinition<TEntity> CreateFilter<T>(T id)
             => Builders<TEntity>.Filter.Eq("_id", id);
 
         private MongoSearchParameters<TEntity> CreateSearchParameters(Action<ISearchParametersBuilder<TEntity>> searchCriteria)

--- a/ChustaSoft.Tools.DBAccess.MongoDb/UnitOfWork.cs
+++ b/ChustaSoft.Tools.DBAccess.MongoDb/UnitOfWork.cs
@@ -1,5 +1,4 @@
-﻿using ChustaSoft.Common.Contracts;
-using System;
+﻿using System;
 using System.Threading.Tasks;
 
 namespace ChustaSoft.Tools.DBAccess

--- a/ChustaSoft.Tools.DBAccess.MongoDb/UnitOfWork.cs
+++ b/ChustaSoft.Tools.DBAccess.MongoDb/UnitOfWork.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using ChustaSoft.Common.Contracts;
+using System;
 using System.Threading.Tasks;
 
 namespace ChustaSoft.Tools.DBAccess


### PR DESCRIPTION
Adds implementation of Mongo repository

Since the repositories need to know the primary Id used in the database, and to remain flexible with respect to existing data models, a structure called the `IKeyResolver` has been added to provide this piece of information. It has three available implementations:
 - The `DefaultKeyResolver`: this is used when no implementation is provided to the constructor of a context. This implementation leverages the `IKeyable` as defined in the common project
- The `IdPropertyKeyResolver`: this implementation looks for a `Id` property
- The `MongoKeyResolver`: this looks for a propery marked with the `BsonId` attribute.

Open questions: Since the `IdProprertyKeyResolver` does effectively the same as the `DefaultKeyResolver` there might not be a lot of added value to have the two. Nevertheless I kept is, since it is the default way of handing Ids in the ChustaSoft ecosystem. Do we get rid of it and remove the dependency altogether?

