### PR TITLE
Refer to wiki on transaction NotSupportedException

### DIFF
--- a/ChustaSoft.Tools.DBAccess.MongoDb.Tests/ChustaSoft.Tools.DBAccess.MongoDb.Tests.csproj
+++ b/ChustaSoft.Tools.DBAccess.MongoDb.Tests/ChustaSoft.Tools.DBAccess.MongoDb.Tests.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="MongoDB.Driver" Version="2.11.2" />
+    <PackageReference Include="Moq" Version="4.16.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/ChustaSoft.Tools.DBAccess.MongoDb.Tests/MongoContextTests.cs
+++ b/ChustaSoft.Tools.DBAccess.MongoDb.Tests/MongoContextTests.cs
@@ -1,0 +1,50 @@
+﻿using MongoDB.Driver;
+using Moq;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace ChustaSoft.Tools.DBAccess.MongoDb.Tests
+{
+    public class MongoContextTests
+    {
+        private const string transactionsNotSupportedMessage = "Standalone servers do not support transactions.";
+        private readonly Mock<IMongoClient> mongoClientMock = new Mock<IMongoClient>();
+        private readonly Mock<IMongoDatabase> mongoDatabaseMock = new Mock<IMongoDatabase>();
+        private MongoContext context;
+
+        [Fact]
+        public async Task Given_StandAloneServer_When_TransactionStarted_Then_ItShouldReferToDocumentation()
+        {
+            // Arrange
+            SetupStandAloneServer();
+
+            // Act
+            var exception = await Assert.ThrowsAsync<NotSupportedException>(
+                () => context.SaveChangesAsync()
+            );
+
+            // Assert
+            Assert.NotNull(exception);
+            Assert.Equal("https://github.com/ChustaSoft/DBAccess/wiki#using-the-mongodb-implementation", exception.HelpLink);
+
+            var expectedMessage = "Transactions are not supported on standalone MongoDb servers. For available options, please refer to https://github.com/ChustaSoft/DBAccess/wiki#using-the-mongodb-implementation";
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
+        private void SetupStandAloneServer()
+        {
+            var clientSessionHandleMock = new Mock<IClientSessionHandle>();
+
+            clientSessionHandleMock
+                .Setup(csh => csh.StartTransaction(default))
+                .Throws(new NotSupportedException(transactionsNotSupportedMessage));
+
+            mongoClientMock
+                .Setup(c => c.StartSessionAsync(default, default))
+                .ReturnsAsync(clientSessionHandleMock.Object);
+
+            context = new MongoContext(mongoClientMock.Object, mongoDatabaseMock.Object);
+        }
+    }
+}


### PR DESCRIPTION
Refers the user in the exception message to the wiki for instructions when the standalone-servers-do-not-support-transactions error is thrown.